### PR TITLE
Support map[interface{}] with string keys in fieldmap's Coerce.

### DIFF
--- a/fieldmap.go
+++ b/fieldmap.go
@@ -47,12 +47,27 @@ type fieldMapC struct {
 
 var stringType = reflect.TypeOf("")
 
+func hasStrictStringKeys(rv reflect.Value) bool {
+	if rv.Type().Key() == stringType {
+		return true
+	}
+	if rv.Type().Key().Kind() != reflect.Interface {
+		return false
+	}
+	for _, k := range rv.MapKeys() {
+		if k.Elem().Type() != stringType {
+			return false
+		}
+	}
+	return true
+}
+
 func (c fieldMapC) Coerce(v interface{}, path []string) (interface{}, error) {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Map {
 		return nil, error_{"map", v, path}
 	}
-	if rv.Type().Key() != stringType {
+	if !hasStrictStringKeys(rv) {
 		return nil, error_{"map[string]", v, path}
 	}
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -322,7 +322,7 @@ func assertFieldMap(c *gc.C, sch schema.Checker) {
 	c.Assert(err, gc.ErrorMatches, `a: expected "A", got bool\(true\)`)
 }
 
-func (s *S) TestFieldMap(c *gc.C) {
+func (s *S) TestFieldMapBasic(c *gc.C) {
 	fields := schema.Fields{
 		"a": schema.Const("A"),
 		"b": schema.Const("B"),
@@ -355,6 +355,20 @@ func (s *S) TestFieldMap(c *gc.C) {
 	out, err = s.sch.Coerce(map[strKey]string{"a": "A"}, aPath)
 	c.Assert(err, gc.ErrorMatches, `<path>: expected map\[string], got map\[schema_test\.strKey]string\(map\[schema_test.strKey]string{"a":"A"}\)`)
 	c.Assert(out, gc.Equals, nil)
+}
+
+func (s *S) TestFieldMapInterfaceKey(c *gc.C) {
+	fields := schema.Fields{
+		"a": schema.Const("A"),
+	}
+	s.sch = schema.FieldMap(fields, nil)
+
+	out, err := s.sch.Coerce(map[interface{}]interface{}{"a": "A"}, aPath)
+	c.Assert(err, gc.IsNil)
+	c.Check(out, gc.DeepEquals, map[string]interface{}{"a": "A"})
+
+	_, err = s.sch.Coerce(map[interface{}]interface{}{1: "A"}, aPath)
+	c.Check(err, gc.ErrorMatches, `<path>: expected map\[string], got map\[interface {}]interface {}\(map\[interface {}]interface {}{1:"A"}\)`)
 }
 
 func (s *S) TestFieldMapDefaultInvalid(c *gc.C) {


### PR DESCRIPTION
This fixes code broken by d8f121c6bb8576fb603e1944ad117c8ed6d669ba.

(Review request: http://reviews.vapour.ws/r/1942/)