### PR TITLE
fix path prefix in StrictFieldMap checker

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -51,15 +51,21 @@ func (c oneOfC) Coerce(v interface{}, path []string) (interface{}, error) {
 	return nil, error_{"", v, path}
 }
 
-// pathAsString returns a string consisting of the path elements. If path
+// pathAsPrefix returns a string consisting of the path elements
+// suitable for using as the prefix of an error message. If path
 // starts with a ".", the dot is omitted.
-func pathAsString(path []string) string {
+func pathAsPrefix(path []string) string {
 	if len(path) == 0 {
 		return ""
 	}
+	var s string
 	if path[0] == "." {
-		return strings.Join(path[1:], "")
+		s = strings.Join(path[1:], "")
 	} else {
-		return strings.Join(path, "")
+		s = strings.Join(path, "")
 	}
+	if s == "" {
+		return ""
+	}
+	return s + ": "
 }

--- a/errors.go
+++ b/errors.go
@@ -14,10 +14,7 @@ type error_ struct {
 }
 
 func (e error_) Error() string {
-	path := pathAsString(e.path)
-	if path != "" {
-		path += ": "
-	}
+	path := pathAsPrefix(e.path)
 	if e.want == "" {
 		return fmt.Sprintf("%sunexpected value %#v", path, e.got)
 	}

--- a/fieldmap.go
+++ b/fieldmap.go
@@ -75,7 +75,7 @@ func (c fieldMapC) Coerce(v interface{}, path []string) (interface{}, error) {
 		for _, k := range rv.MapKeys() {
 			ks := k.String()
 			if _, ok := c.fields[ks]; !ok {
-				return nil, fmt.Errorf("%v: unknown key %q (value %q)", pathAsString(path), ks, rv.MapIndex(k).Interface())
+				return nil, fmt.Errorf("%sunknown key %q (value %#v)", pathAsPrefix(path), ks, rv.MapIndex(k).Interface())
 			}
 		}
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -399,6 +399,10 @@ func (s *S) TestStrictFieldMap(c *gc.C) {
 	out, err := s.sch.Coerce(map[string]interface{}{"a": "A", "b": "B", "d": "D"}, aPath)
 	c.Assert(out, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `<path>: unknown key "d" \(value "D"\)`)
+
+	out, err = s.sch.Coerce(map[string]interface{}{"a": "A", "b": "B", "d": "D"}, nil)
+	c.Assert(out, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, `unknown key "d" \(value "D"\)`)
 }
 
 func (s *S) TestSchemaMap(c *gc.C) {


### PR DESCRIPTION
With an empty path, the message would contain a double colon. This fixes that.

(Review request: http://reviews.vapour.ws/r/2312/)