### PR TITLE
Added schema.Nil() and schema.NonEmptyString()

### DIFF
--- a/const.go
+++ b/const.go
@@ -24,3 +24,26 @@ func (c constC) Coerce(v interface{}, path []string) (interface{}, error) {
 	}
 	return nil, error_{fmt.Sprintf("%#v", c.value), v, path}
 }
+
+// Empty returns a Checker that only succeeds if the input is an empty value
+// (nil). To tweak the error message, valueLabel can contain a label of the
+// value being checked to be empty, e.g. "my special name". If valueLabel is "",
+// "value" will be used as a label instead.
+func Empty(valueLabel string) Checker {
+	if valueLabel == "" {
+		valueLabel = "value"
+	}
+	return emptyC{valueLabel}
+}
+
+type emptyC struct {
+	valueLabel string
+}
+
+func (c emptyC) Coerce(v interface{}, path []string) (interface{}, error) {
+	if reflect.DeepEqual(v, nil) {
+		return v, nil
+	}
+	label := fmt.Sprintf("empty %s", c.valueLabel)
+	return nil, error_{label, v, path}
+}

--- a/const.go
+++ b/const.go
@@ -25,22 +25,30 @@ func (c constC) Coerce(v interface{}, path []string) (interface{}, error) {
 	return nil, error_{fmt.Sprintf("%#v", c.value), v, path}
 }
 
-// Empty returns a Checker that only succeeds if the input is an empty value
-// (nil). To tweak the error message, valueLabel can contain a label of the
-// value being checked to be empty, e.g. "my special name". If valueLabel is "",
-// "value" will be used as a label instead.
-func Empty(valueLabel string) Checker {
+// Nil returns a Checker that only succeeds if the input is nil. To tweak the
+// error message, valueLabel can contain a label of the value being checked to
+// be empty, e.g. "my special name". If valueLabel is "", "value" will be used
+// as a label instead.
+//
+// Example 1:
+// schema.Nil("widget").Coerce(42, nil) will return an error message
+// like `expected empty widget, got int(42)`.
+//
+// Example 2:
+// schema.Nil("").Coerce("", nil) will return an error message like
+// `expected empty value, got string("")`.
+func Nil(valueLabel string) Checker {
 	if valueLabel == "" {
 		valueLabel = "value"
 	}
-	return emptyC{valueLabel}
+	return nilC{valueLabel}
 }
 
-type emptyC struct {
+type nilC struct {
 	valueLabel string
 }
 
-func (c emptyC) Coerce(v interface{}, path []string) (interface{}, error) {
+func (c nilC) Coerce(v interface{}, path []string) (interface{}, error) {
 	if reflect.DeepEqual(v, nil) {
 		return v, nil
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -35,30 +35,30 @@ func (s *S) TestConst(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `<path>: expected "foo", got nothing`)
 }
 
-func (s *S) TestEmptySuccess(c *gc.C) {
+func (s *S) TestNilSuccess(c *gc.C) {
 	assertSuccess := func() {
 		out, err := s.sch.Coerce(nil, aPath)
 		c.Assert(err, gc.IsNil)
 		c.Assert(out, gc.IsNil)
 	}
 
-	s.sch = schema.Empty("")
+	s.sch = schema.Nil("")
 	assertSuccess()
 
-	s.sch = schema.Empty("any label")
+	s.sch = schema.Nil("any label")
 	assertSuccess()
 }
 
-var nonEmptyValues = []interface{}{42, "", "foo", false, 3.14, 0}
+var nonNilValues = []interface{}{42, "", "foo", false, 3.14, 0}
 
-func (s *S) TestEmptyFailuresWithEmptyLabel(c *gc.C) {
-	s.sch = schema.Empty("")
-	s.testCheckerFailsForEachBadValueWithErrorPrefix(c, nonEmptyValues, `<path>: expected empty value`)
+func (s *S) TestNilFailuresWithEmptyLabel(c *gc.C) {
+	s.sch = schema.Nil("")
+	s.testCheckerFailsForEachBadValueWithErrorPrefix(c, nonNilValues, `<path>: expected empty value`)
 }
 
-func (s *S) TestEmptyFailuresWithNonEmptyLabel(c *gc.C) {
-	s.sch = schema.Empty("wallet")
-	s.testCheckerFailsForEachBadValueWithErrorPrefix(c, nonEmptyValues, `<path>: expected empty wallet`)
+func (s *S) TestNilFailuresWithNonEmptyLabel(c *gc.C) {
+	s.sch = schema.Nil("wallet")
+	s.testCheckerFailsForEachBadValueWithErrorPrefix(c, nonNilValues, `<path>: expected empty wallet`)
 }
 
 func (s *S) TestNonEmptyStringSuccess(c *gc.C) {

--- a/strings.go
+++ b/strings.go
@@ -96,10 +96,18 @@ func (c stringifiedC) Coerce(v interface{}, path []string) (interface{}, error) 
 	return fmt.Sprintf("%#v", v), nil
 }
 
-// NonEmptyString returns a Checker that only accepts non-empty strings.succeeds
-// if the input is a non-empty string. To tweak the error message, valueLabel
-// can contain a label of the value being checked, e.g. "my special name". If
-// valueLabel is "", "string" will be used as a label instead.
+// NonEmptyString returns a Checker that only accepts non-empty strings. To
+// tweak the error message, valueLabel can contain a label of the value being
+// checked, e.g. "my special name". If valueLabel is "", "string" will be used
+// as a label instead.
+//
+// Example 1:
+// schema.NonEmptyString("widget").Coerce("", nil) will return an error message
+// like `expected non-empty widget, got string("")`.
+//
+// Example 2:
+// schema.NonEmptyString("").Coerce("", nil) will return an error message like
+// `expected non-empty string, got string("")`.
 func NonEmptyString(valueLabel string) Checker {
 	if valueLabel == "" {
 		valueLabel = "string"

--- a/strings.go
+++ b/strings.go
@@ -95,3 +95,31 @@ func (c stringifiedC) Coerce(v interface{}, path []string) (interface{}, error) 
 	}
 	return fmt.Sprintf("%#v", v), nil
 }
+
+// NonEmptyString returns a Checker that only accepts non-empty strings.succeeds
+// if the input is a non-empty string. To tweak the error message, valueLabel
+// can contain a label of the value being checked, e.g. "my special name". If
+// valueLabel is "", "string" will be used as a label instead.
+func NonEmptyString(valueLabel string) Checker {
+	if valueLabel == "" {
+		valueLabel = "string"
+	}
+	return nonEmptyStringC{valueLabel}
+}
+
+type nonEmptyStringC struct {
+	valueLabel string
+}
+
+func (c nonEmptyStringC) Coerce(v interface{}, path []string) (interface{}, error) {
+	label := fmt.Sprintf("non-empty %s", c.valueLabel)
+	invalidError := error_{label, v, path}
+
+	if v == nil || reflect.TypeOf(v).Kind() != reflect.String {
+		return nil, invalidError
+	}
+	if stringValue := reflect.ValueOf(v).String(); stringValue != "" {
+		return stringValue, nil
+	}
+	return nil, invalidError
+}


### PR DESCRIPTION
A couple of convenient new checkers:
 * Nil("value label") (or with ""): fails if value is not nil.
 * NonEmptyString("value label") (or with ""): fails if the value is not
   a non-empty string.

(Review request: http://reviews.vapour.ws/r/4019/)