### PR TITLE
Add TimeDuration and Size schema checkers.

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -624,3 +624,59 @@ func (s *S) TestStringified(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Check(out, gc.Equals, `map[string]string{"a":"b"}`)
 }
+
+func (s *S) TestTimeDuration(c *gc.C) {
+	s.sch = schema.TimeDuration()
+
+	var empty time.Duration
+
+	out, err := s.sch.Coerce("", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(out, gc.Equals, empty)
+
+	value, _ := time.ParseDuration("18h")
+
+	out, err = s.sch.Coerce("18h", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(out, gc.Equals, value)
+
+	out, err = s.sch.Coerce("failure", aPath)
+	c.Assert(err.Error(), gc.Equals, "time: invalid duration failure")
+
+	out, err = s.sch.Coerce(42, aPath)
+	c.Assert(out, gc.IsNil)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected string or time.Duration, got int(42)")
+
+	out, err = s.sch.Coerce(nil, aPath)
+	c.Assert(out, gc.IsNil)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected string or time.Duration, got nothing")
+}
+
+func (s *S) TestSize(c *gc.C) {
+	s.sch = schema.Size()
+	//Invalid size
+	out, err := s.sch.Coerce("18X", aPath)
+	c.Assert(err.Error(), gc.Equals, "invalid multiplier suffix \"X\", expected one of MGTPEZY")
+	c.Assert(out, gc.IsNil)
+
+	//Valid Size
+	out, err = s.sch.Coerce("18G", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(out, gc.Equals, uint64(18432))
+
+	//Empty string
+	out, err = s.sch.Coerce("", aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected empty string, got string(\"\")")
+	c.Assert(out, gc.IsNil)
+
+	//Nil
+	out, err = s.sch.Coerce(nil, aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected string, got nothing")
+	c.Assert(out, gc.IsNil)
+
+	//Invalid type
+	var foo int
+	out, err = s.sch.Coerce(foo, aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected string, got int(0)")
+	c.Assert(out, gc.IsNil)
+}

--- a/size.go
+++ b/size.go
@@ -1,0 +1,42 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package schema
+
+import (
+	"github.com/juju/utils"
+	"reflect"
+)
+
+// Size returns a Checker that accepts a string value, and returns
+// the parsed string as a size in mebibytes see: https://godoc.org/github.com/juju/utils#ParseSize
+func Size() Checker {
+	return sizeC{}
+}
+
+type sizeC struct{}
+
+// Coerce implements Checker Coerce method.
+func (c sizeC) Coerce(v interface{}, path []string) (interface{}, error) {
+	if v == nil {
+		return nil, error_{"string", v, path}
+	}
+
+	typeOf := reflect.TypeOf(v).Kind()
+	if typeOf != reflect.String {
+		return nil, error_{"string", v, path}
+	}
+
+	value := reflect.ValueOf(v).String()
+	if value == "" {
+		return nil, error_{"empty string", v, path}
+	}
+
+	v, err := utils.ParseSize(value)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}

--- a/time_duration.go
+++ b/time_duration.go
@@ -1,0 +1,42 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package schema
+
+import (
+	"reflect"
+	"time"
+)
+
+// TimeDuration returns a Checker that accepts a string value, and returns
+// the parsed time.Duration value. Emtpy strings are considered empty time.Duration
+func TimeDuration() Checker {
+	return timeDurationC{}
+}
+
+type timeDurationC struct{}
+
+// Coerce implements Checker Coerce method.
+func (c timeDurationC) Coerce(v interface{}, path []string) (interface{}, error) {
+	if v == nil {
+		return nil, error_{"string or time.Duration", v, path}
+	}
+
+	var empty time.Duration
+	switch reflect.TypeOf(v).Kind() {
+	case reflect.TypeOf(empty).Kind():
+		return v, nil
+	case reflect.String:
+		vstr := reflect.ValueOf(v).String()
+		if vstr == "" {
+			return empty, nil
+		}
+		v, err := time.ParseDuration(vstr)
+		if err != nil {
+			return nil, err
+		}
+		return v, nil
+	default:
+		return nil, error_{"string or time.Duration", v, path}
+	}
+}


### PR DESCRIPTION
This commit adds 2 new schema checkers:

1) TimeDuration: it receives a string and returns a
time.Duration object, empty string is considered a empty time.Duration.

2) Size: it receives a string and returns a uint64
value in Mebibytes, see: https://godoc.org/github.com/juju/utils#ParseSize

Signed-off-by: Jorge Niedbalski <jnr@metaklass.org>

(Review request: http://reviews.vapour.ws/r/5487/)