### PR TITLE
lp1613839 - Add implicit int and uint to float64 conversion

### DIFF
--- a/numeric.go
+++ b/numeric.go
@@ -188,10 +188,12 @@ func (c floatC) Coerce(v interface{}, path []string) (interface{}, error) {
 		return nil, error_{"float", v, path}
 	}
 	switch reflect.TypeOf(v).Kind() {
-	case reflect.Float32:
-	case reflect.Float64:
+        case reflect.Float32, reflect.Float64:
+        case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+        case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 	default:
 		return nil, error_{"float", v, path}
 	}
-	return reflect.ValueOf(v).Float(), nil
+	var floatValue float64
+	return reflect.ValueOf(v).Convert( reflect.TypeOf(floatValue) ).Float() , nil
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -333,6 +333,26 @@ func (s *S) TestFloat(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(out, gc.Equals, float64(1.0))
 
+	out, err = sch.Coerce(int8(1), aPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(out, gc.Equals, float64(1))
+
+	out, err = sch.Coerce(int64( math.MaxInt64 ), aPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(out, gc.Equals, float64( math.MaxInt64 ))
+
+	out, err = sch.Coerce(int64( math.MinInt64 ), aPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(out, gc.Equals, float64( math.MinInt64 ))
+
+	out, err = sch.Coerce(uint64( 0 ), aPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(out, gc.Equals, float64( 0 ))
+
+	out, err = sch.Coerce(uint64( math.MaxUint64 ), aPath)
+	c.Assert(err, gc.IsNil)
+	c.Assert(out, gc.Equals, float64( math.MaxUint64 ))
+
 	out, err = sch.Coerce(true, aPath)
 	c.Assert(out, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, `<path>: expected float, got bool\(true\)`)


### PR DESCRIPTION
This solves lp1613839. 

The float checker only accepts float values, and, in contradiction to other checkers, does not do any simple conversions. This leads to a problem where any number specified without decimal part (eg 1) or with 0 decimal part (1.0) cannot be used in YAML files as it causes juju error.

This is a simple patch which allows int and uint conversions to float64 within float checker.