### PR TITLE
add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/juju/schema
+
+go 1.11
+
+require (
+	github.com/kr/pretty v0.1.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/size.go
+++ b/size.go
@@ -4,8 +4,12 @@
 package schema
 
 import (
-	"github.com/juju/utils"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
 	"reflect"
+	"unicode"
 )
 
 // Size returns a Checker that accepts a string value, and returns
@@ -32,11 +36,57 @@ func (c sizeC) Coerce(v interface{}, path []string) (interface{}, error) {
 		return nil, error_{"empty string", v, path}
 	}
 
-	v, err := utils.ParseSize(value)
+	v, err := parseSize(value)
 
 	if err != nil {
 		return nil, err
 	}
 
 	return v, nil
+}
+
+// parseSize parses the string as a size, in mebibytes.
+//
+// The string must be a is a non-negative number with
+// an optional multiplier suffix (M, G, T, P, E, Z, or Y).
+// If the suffix is not specified, "M" is implied.
+//
+// Note: this function has been copied from github.com/juju/utils
+// to avoid that heavy dependency.
+func parseSize(str string) (MB uint64, err error) {
+	// Find the first non-digit/period:
+	i := strings.IndexFunc(str, func(r rune) bool {
+		return r != '.' && !unicode.IsDigit(r)
+	})
+	var multiplier float64 = 1
+	if i > 0 {
+		suffix := str[i:]
+		multiplier = 0
+		for j := 0; j < len(sizeSuffixes); j++ {
+			base := string(sizeSuffixes[j])
+			// M, MB, or MiB are all valid.
+			switch suffix {
+			case base, base + "B", base + "iB":
+				multiplier = float64(sizeSuffixMultiplier(j))
+				break
+			}
+		}
+		if multiplier == 0 {
+			return 0, fmt.Errorf("invalid multiplier suffix %q, expected one of %s", suffix, []byte(sizeSuffixes))
+		}
+		str = str[:i]
+	}
+
+	val, err := strconv.ParseFloat(str, 64)
+	if err != nil || val < 0 {
+		return 0, fmt.Errorf("expected a non-negative number, got %q", str)
+	}
+	val *= multiplier
+	return uint64(math.Ceil(val)), nil
+}
+
+var sizeSuffixes = "MGTPEZY"
+
+func sizeSuffixMultiplier(i int) int {
+	return 1 << uint(i*10)
 }

--- a/size_test.go
+++ b/size_test.go
@@ -1,0 +1,74 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package schema
+
+import (
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&sizeSuite{})
+
+type sizeSuite struct {}
+
+func (*sizeSuite) TestParseSize(c *gc.C) {
+	type test struct {
+		in  string
+		out uint64
+		err string
+	}
+	tests := []test{{
+		in:  "",
+		err: `expected a non-negative number, got ""`,
+	}, {
+		in:  "-1",
+		err: `expected a non-negative number, got "-1"`,
+	}, {
+		in:  "1MZ",
+		err: `invalid multiplier suffix "MZ", expected one of MGTPEZY`,
+	}, {
+		in:  "0",
+		out: 0,
+	}, {
+		in:  "123",
+		out: 123,
+	}, {
+		in:  "1M",
+		out: 1,
+	}, {
+		in:  "0.5G",
+		out: 512,
+	}, {
+		in:  "0.5GB",
+		out: 512,
+	}, {
+		in:  "0.5GiB",
+		out: 512,
+	}, {
+		in:  "0.5T",
+		out: 524288,
+	}, {
+		in:  "0.5P",
+		out: 536870912,
+	}, {
+		in:  "0.0009765625E",
+		out: 1073741824,
+	}, {
+		in:  "1Z",
+		out: 1125899906842624,
+	}, {
+		in:  "1Y",
+		out: 1152921504606846976,
+	}}
+	for i, test := range tests {
+		c.Logf("test %d: %+v", i, test)
+		size, err := parseSize(test.in)
+		if test.err != "" {
+			c.Assert(err, gc.NotNil)
+			c.Assert(err, gc.ErrorMatches, test.err)
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(size, gc.Equals, test.out)
+		}
+	}
+}


### PR DESCRIPTION
Also reduce dependencies by copying ParseSize from juju/utils.
The juju/utils package is large and has many dependencies;
packages should be able use schema without needing that too.