### PR TITLE
include the path in the errors generated due to parsing errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -23,3 +23,8 @@ func (e error_) Error() string {
 	}
 	return fmt.Sprintf("%sexpected %s, got %T(%#v)", path, e.want, e.got, e.got)
 }
+
+func parseError(path []string, expected string, err error) error {
+	prefix := pathAsPrefix(path)
+	return fmt.Errorf("%sconversion to %s: %s", prefix, expected, err.Error())
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -337,21 +337,21 @@ func (s *S) TestFloat(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(out, gc.Equals, float64(1))
 
-	out, err = sch.Coerce(int64( math.MaxInt64 ), aPath)
+	out, err = sch.Coerce(int64(math.MaxInt64), aPath)
 	c.Assert(err, gc.IsNil)
-	c.Assert(out, gc.Equals, float64( math.MaxInt64 ))
+	c.Assert(out, gc.Equals, float64(math.MaxInt64))
 
-	out, err = sch.Coerce(int64( math.MinInt64 ), aPath)
+	out, err = sch.Coerce(int64(math.MinInt64), aPath)
 	c.Assert(err, gc.IsNil)
-	c.Assert(out, gc.Equals, float64( math.MinInt64 ))
+	c.Assert(out, gc.Equals, float64(math.MinInt64))
 
-	out, err = sch.Coerce(uint64( 0 ), aPath)
+	out, err = sch.Coerce(uint64(0), aPath)
 	c.Assert(err, gc.IsNil)
-	c.Assert(out, gc.Equals, float64( 0 ))
+	c.Assert(out, gc.Equals, float64(0))
 
-	out, err = sch.Coerce(uint64( math.MaxUint64 ), aPath)
+	out, err = sch.Coerce(uint64(math.MaxUint64), aPath)
 	c.Assert(err, gc.IsNil)
-	c.Assert(out, gc.Equals, float64( math.MaxUint64 ))
+	c.Assert(out, gc.Equals, float64(math.MaxUint64))
 
 	out, err = sch.Coerce(true, aPath)
 	c.Assert(out, gc.IsNil)
@@ -696,7 +696,7 @@ func (s *S) TestTime(c *gc.C) {
 
 	out, err = sch.Coerce("invalid", aPath)
 	c.Assert(out, gc.IsNil)
-	c.Assert(err.Error(), gc.Equals, `parsing time "invalid" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "invalid" as "2006"`)
+	c.Assert(err.Error(), gc.Equals, `<path>: conversion to time: parsing time "invalid" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "invalid" as "2006"`)
 
 	out, err = sch.Coerce(42, aPath)
 	c.Assert(out, gc.IsNil)
@@ -755,7 +755,7 @@ func (s *S) TestTimeDuration(c *gc.C) {
 	c.Assert(out, gc.Equals, value)
 
 	out, err = sch.Coerce("failure", aPath)
-	c.Assert(err.Error(), gc.Equals, "time: invalid duration failure")
+	c.Assert(err.Error(), gc.Equals, "<path>: conversion to duration: time: invalid duration failure")
 
 	out, err = sch.Coerce(42, aPath)
 	c.Assert(out, gc.IsNil)

--- a/time.go
+++ b/time.go
@@ -32,7 +32,7 @@ func (c timeC) Coerce(v interface{}, path []string) (interface{}, error) {
 		}
 		v, err := time.Parse(time.RFC3339Nano, vstr)
 		if err != nil {
-			return nil, err
+			return nil, parseError(path, "time", err)
 		}
 		return v, nil
 	default:

--- a/time_duration.go
+++ b/time_duration.go
@@ -33,7 +33,7 @@ func (c timeDurationC) Coerce(v interface{}, path []string) (interface{}, error)
 		}
 		v, err := time.ParseDuration(vstr)
 		if err != nil {
-			return nil, err
+			return nil, parseError(path, "duration", err)
 		}
 		return v, nil
 	default:


### PR DESCRIPTION
While trying to use a duration schema checker, it became clear that if there is an error in the parsing of the string, the path isn't included in the error. This is really needed when you have maps of types.