### PR TITLE
Encode time.Duration as string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/juju/schema
 
-go 1.11
+go 1.20
+
+require gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
+	github.com/kr/text v0.1.0 // indirect
 )

--- a/schema_test.go
+++ b/schema_test.go
@@ -739,33 +739,6 @@ func (s *S) TestStringified(c *gc.C) {
 	c.Check(out, gc.Equals, `map[string]string{"a":"b"}`)
 }
 
-func (s *S) TestTimeDuration(c *gc.C) {
-	sch := schema.TimeDuration()
-
-	var empty time.Duration
-
-	out, err := sch.Coerce("", aPath)
-	c.Assert(err, gc.IsNil)
-	c.Assert(out, gc.Equals, empty)
-
-	value, _ := time.ParseDuration("18h")
-
-	out, err = sch.Coerce("18h", aPath)
-	c.Assert(err, gc.IsNil)
-	c.Assert(out, gc.Equals, value)
-
-	out, err = sch.Coerce("failure", aPath)
-	c.Assert(err.Error(), gc.Equals, "<path>: conversion to duration: time: invalid duration \"failure\"")
-
-	out, err = sch.Coerce(42, aPath)
-	c.Assert(out, gc.IsNil)
-	c.Assert(err.Error(), gc.Equals, "<path>: expected string or time.Duration, got int(42)")
-
-	out, err = sch.Coerce(nil, aPath)
-	c.Assert(out, gc.IsNil)
-	c.Assert(err.Error(), gc.Equals, "<path>: expected string or time.Duration, got nothing")
-}
-
 func (s *S) TestSize(c *gc.C) {
 	sch := schema.Size()
 	//Invalid size

--- a/time_duration.go
+++ b/time_duration.go
@@ -8,8 +8,9 @@ import (
 	"time"
 )
 
-// TimeDuration returns a Checker that accepts a string value, and returns
-// the parsed time.Duration value. Emtpy strings are considered empty time.Duration
+// TimeDuration returns a Checker that accepts a string or time.Duration value,
+// and returns the parsed time.Duration value.
+// Empty strings are considered empty time.Duration.
 func TimeDuration() Checker {
 	return timeDurationC{}
 }
@@ -18,8 +19,35 @@ type timeDurationC struct{}
 
 // Coerce implements Checker Coerce method.
 func (c timeDurationC) Coerce(v interface{}, path []string) (interface{}, error) {
+	return asTimeDuration(v, path)
+}
+
+// TimeDurationString returns a Checker that accepts a string or time.Duration
+// value, and returns the time.Duration encoded as a string. The encoding
+// uses the time.Duration.String() method.
+// Empty strings are considered empty time.Duration.
+func TimeDurationString() Checker {
+	return timeDurationStringC{}
+}
+
+type timeDurationStringC struct{}
+
+// Coerce implements Checker Coerce method.
+func (c timeDurationStringC) Coerce(v interface{}, path []string) (interface{}, error) {
+	dur, err := asTimeDuration(v, path)
+	if err != nil || dur == nil {
+		return "", err
+	}
+	d, ok := dur.(time.Duration)
+	if !ok {
+		return "", nil
+	}
+	return d.String(), nil
+}
+
+func asTimeDuration(v interface{}, path []string) (interface{}, error) {
 	if v == nil {
-		return nil, error_{"string or time.Duration", v, path}
+		return nil, error_{want: "string or time.Duration", got: v, path: path}
 	}
 
 	var empty time.Duration

--- a/time_duration_test.go
+++ b/time_duration_test.go
@@ -1,0 +1,80 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package schema_test
+
+import (
+	"time"
+
+	"github.com/juju/schema"
+	gc "gopkg.in/check.v1"
+)
+
+type timeDurationSuite struct{}
+
+var _ = gc.Suite(&timeDurationSuite{})
+
+func (s *timeDurationSuite) TestTimeDuration(c *gc.C) {
+	sch := schema.TimeDuration()
+
+	var empty time.Duration
+
+	out, err := sch.Coerce("", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Check(out, gc.Equals, empty)
+
+	value, _ := time.ParseDuration("18h")
+
+	out, err = sch.Coerce("18h", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Check(out, gc.Equals, value)
+
+	out, err = sch.Coerce("failure", aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: conversion to duration: time: invalid duration \"failure\"")
+	c.Check(out, gc.IsNil)
+
+	out, err = sch.Coerce(42, aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected string or time.Duration, got int(42)")
+	c.Check(out, gc.IsNil)
+
+	out, err = sch.Coerce(nil, aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected string or time.Duration, got nothing")
+	c.Check(out, gc.IsNil)
+}
+
+func (s *timeDurationSuite) TestTimeDurationString(c *gc.C) {
+	sch := schema.TimeDurationString()
+
+	out, err := sch.Coerce("", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Check(out, gc.Equals, "0s")
+
+	out, err = sch.Coerce("18h", aPath)
+	c.Assert(err, gc.IsNil)
+	// We get the long form because it's hours are greater than seconds.
+	c.Check(out, gc.Equals, "18h0m0s")
+
+	out, err = sch.Coerce("42m", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Check(out, gc.Equals, "42m0s")
+
+	out, err = sch.Coerce("42s", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Check(out, gc.Equals, "42s")
+
+	out, err = sch.Coerce("42ms", aPath)
+	c.Assert(err, gc.IsNil)
+	c.Check(out, gc.Equals, "42ms")
+
+	out, err = sch.Coerce("failure", aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: conversion to duration: time: invalid duration \"failure\"")
+	c.Check(out, gc.Equals, "")
+
+	out, err = sch.Coerce(42, aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected string or time.Duration, got int(42)")
+	c.Check(out, gc.Equals, "")
+
+	out, err = sch.Coerce(nil, aPath)
+	c.Assert(err.Error(), gc.Equals, "<path>: expected string or time.Duration, got nothing")
+	c.Check(out, gc.Equals, "")
+}


### PR DESCRIPTION
The following is a fix for issues where we would like the properties of time.Duration schema coercion, but the result is always a string. The problem with using the time.Duration, is that it has no json encoding method. The consequence of this is that when time.Duration is passed over the wire, the json encoders treat values as float64. We then have no way to get back to a time.Duration without wrapping all the locations that we want a time.Duration that could be float64 in all call sites.

Another solution would be to allow the TimeDuration to accept float64 and to do the right thing there except what if you want to prevent other floats from being accepted in that location. The schema coercion becomes too weak. All float64s are valid time.Durations. Unlike strings, they have to conform to a specific format that can be parsed correctly and more importantly rejected if they're wrong.

---

I had to bump the go version as the test wouldn't run any more.